### PR TITLE
for your consideration

### DIFF
--- a/git-strip-new-whitespace
+++ b/git-strip-new-whitespace
@@ -13,7 +13,7 @@ if [ -f ".git/MERGE_MODE" ]; then
   exit 1
 fi
 
-STAGED_CHANGES="$(git diff --cached)"
+STAGED_CHANGES="$(git diff --cached --ignore-space-change)"
 if [ "$STAGED_CHANGES" != "" ]; then
   echo "Stripping trailing spaces from index"
   git reset 2> /dev/null 1> /dev/null


### PR DESCRIPTION
I had lines which were nothing but two spaces being removed via emacs.  This patch allows git-strip-new-whitespace to remove those as well.
